### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/Incident-Response/Tools/cyphon/cyphon/alerts/views.py
+++ b/Incident-Response/Tools/cyphon/cyphon/alerts/views.py
@@ -124,7 +124,7 @@ class AlertViewSet(CustomModelViewSet):
 
         use_redaction = self.request.user.use_redaction
 
-        if self.action is 'list':
+        if self.action == 'list':
             if use_redaction:
                 return RedactedAlertListSerializer
             else:

--- a/Incident-Response/Tools/cyphon/cyphon/articles/views.py
+++ b/Incident-Response/Tools/cyphon/cyphon/articles/views.py
@@ -63,7 +63,7 @@ class ArticleViewSet(viewsets.ModelViewSet):
                    % type(self).__name__)
             raise RuntimeError(msg)
 
-        if self.action is 'list':
+        if self.action == 'list':
             return ArticleListSerializer
         else:
             return self.serializer_class

--- a/Incident-Response/Tools/cyphon/cyphon/engines/elasticsearch/sorter.py
+++ b/Incident-Response/Tools/cyphon/cyphon/engines/elasticsearch/sorter.py
@@ -61,7 +61,7 @@ class ElasticsearchSorter(Sorter):
             data_type = get_data_type(sort.field_type)
 
             # don't sort fields that are analyzed/tokenized
-            if data_type is not 'text':
+            if data_type != 'text':
                 params.append({
                     sort.field_name: {
                         'order': self._SORT_ORDERS[sort.order],

--- a/Incident-Response/Tools/cyphon/cyphon/tags/views.py
+++ b/Incident-Response/Tools/cyphon/cyphon/tags/views.py
@@ -67,7 +67,7 @@ class TagViewSet(viewsets.ModelViewSet):
                    % type(self).__name__)
             raise RuntimeError(msg)
 
-        if self.action is 'list':
+        if self.action == 'list':
             return TagListSerializer
         else:
             return self.serializer_class

--- a/Incident-Response/Tools/cyphon/cyphon/target/locations/models.py
+++ b/Incident-Response/Tools/cyphon/cyphon/target/locations/models.py
@@ -136,13 +136,13 @@ class Location(models.Model):
         returns the smallest rectangle that encompasses the Location's
         geometry. Otherwise returns None.
         """
-        if self.shape is 'Circle':
+        if self.shape == 'Circle':
             return shapes.convert_circle_to_rectangle(self.geom, self.buffer_m)
 
-        elif self.shape is'Rectangle':
+        elif self.shape == 'Rectangle':
             return self.geom
 
-        elif self.shape is 'Polygon' or self.shape is 'MultiPolygon':
+        elif self.shape in ('Polygon', 'MultiPolygon'):
             return self.geom.envelope
 
         else:
@@ -156,13 +156,13 @@ class Location(models.Model):
         the point on the geometry farthest from the centroid. Otherwise returns
         None.
         """
-        if self.shape is 'Circle':
+        if self.shape == 'Circle':
             return units.meters_to_km(self.buffer_m)
 
-        elif self.shape is'Rectangle' or self.shape is 'Polygon':
+        elif self.shape in ('Rectangle', 'Polygon'):
             return shapes.calculate_polygon_radius_km(self.geom)
 
-        elif self.shape is 'MultiPolygon':
+        elif self.shape == 'MultiPolygon':
             return shapes.calculate_multipoly_radius_km(self.geom)
 
         else:


### PR DESCRIPTION
We propose these changes because identity is not the same thing as equality in Python...

$ `python3`
```
>>> windows = "window"
>>> windows += "s"
>>> windows == "windows"
True
>>> windows is "windows"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```